### PR TITLE
build(pom): add Checkstyle plugin for code quality enforcement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,23 @@
         </executions>
       </plugin>
 
+       <!-- Check style Plugin for Lint Checks -->
+      <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-checkstyle-plugin</artifactId>
+      <version>3.1.2</version>
+      <configuration>
+        <failOnViolation>false</failOnViolation> 
+      </configuration>
+      <executions>
+        <execution>
+          <goals>
+            <goal>check</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
This PR integrates the Checkstyle plugin into the project to enforce consistent Java code style and improve overall code quality.