### PR TITLE
chore(gitops): update image tag for dev environment rollout (#11)

### DIFF
--- a/.github/workflows/pharma-ci-cd.yaml
+++ b/.github/workflows/pharma-ci-cd.yaml
@@ -63,7 +63,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GHCR_TOKEN }}
 
   gitleaks-scan:
-    if: false
     name: Gitleaks Secret Scan
     runs-on: ubuntu-latest
     needs: build-and-test
@@ -119,7 +118,6 @@ jobs:
           #   -Dsonar.qualitygate.wait=true
 
   trivy-fs-scan:
-    if: false
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
     needs: build-and-test
@@ -146,7 +144,6 @@ jobs:
           path: trivy-report.txt
 
   docker-build-and-scan:
-    if: false
     name: Docker Build and Scan
     runs-on: ubuntu-latest
     needs: [build-and-test,trivy-fs-scan]
@@ -175,7 +172,7 @@ jobs:
       - name: Build Docker Image
         run: |
           USERNAME=$(echo "${{ secrets.GHCR_USERNAME }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE_TAG=ghcr.io/$USERNAME/springboot-app:${{ github.sha }}
+          IMAGE_TAG=ghcr.io/$USERNAME/pharma-dev:${{ github.sha }}
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
           docker build -t $IMAGE_TAG .
 
@@ -193,13 +190,13 @@ jobs:
       - name: Push Image to GHCR & ACR
         run: |
           USERNAME=$(echo "${{ secrets.GHCR_USERNAME }}" | tr '[:upper:]' '[:lower:]')
-          GHCR_TAG=ghcr.io/$USERNAME/springboot-app:${{ github.sha }}
+          GHCR_TAG=ghcr.io/$USERNAME/pharma-dev:${{ github.sha }}
           docker push $GHCR_TAG
 
   push-artifact-to-nexus:
     name: Push Artifact to Nexus
     runs-on: ubuntu-latest
-    # needs: docker-build-and-scan
+    needs: docker-build-and-scan
     environment: dev
 
     steps:
@@ -222,3 +219,42 @@ jobs:
         run: |
           mvn deploy \
             -DaltDeploymentRepository=nexus::default::http://${{ secrets.NEXUS_USERNAME }}:${{ secrets.NEXUS_PASSWORD }}@98.70.35.194:8081/repository/maven-snapshots/
+
+
+  update-gitops-dev:
+    needs: docker-build-and-scan
+    runs-on: ubuntu-latest
+    environment:
+      name: dev
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'develop'
+    steps:
+    - name: Checkout GitOps Repo
+      uses: actions/checkout@v3
+      with:
+        repository: Vikas-Prince/test-ops
+        token: ${{ secrets.GHCR_TOKEN }}
+        path: test-ops
+
+    - name: Set Git user config
+      run: |
+        cd test-ops
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
+    - name: Update image tag in Dev YAML (GHCR)
+      run: |
+        cd test-ops
+        IMAGE_TAG=ghcr.io/${{ github.repository_owner }}/pharma-dev:${{ github.sha }}
+        sed -i "s|image: .*|image: $IMAGE_TAG|" environments/dev/rollout-patch.yaml
+    - name: Create PR to GitOps (Dev)
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GHCR_TOKEN }}
+        commit-message: "chore(dev): update pharma-dev image tag to ghcr.io/${{ github.repository_owner }}/pharma-dev:${{ github.sha }}"
+        title: "Deploy to Dev - ghcr.io/${{ github.repository_owner }}/pharma-dev:${{ github.sha }}"
+        body: |
+          Automated deployment to the Dev environment.
+          This PR updates the image tag for pharma-dev to:
+          `ghcr.io/${{ github.repository_owner }}/pharma-dev:${{ github.sha }}`
+        base: main
+        branch: auto/update-dev-${{ github.sha }}
+        path: test-ops


### PR DESCRIPTION
## Summary  

This PR automates the image tag update in the GitOps repository for the **Dev environment**, triggering ArgoCD-based deployment.

>  For testing purposes, the update is performed on a **test GitOps repository**, not the main GitOps repo.

---

## What’s Included?

- [x] Clone test GitOps repository  
- [x] Use `sed` to update image tag in `environments/dev/rollout-patch.yaml`  
- [x] Automatically raise PR using `peter-evans/create-pull-request` GitHub Action  
- [x] GitHub Actions workflow triggered on successful image build  

---

## Acceptance Criteria

- [x] PR is raised in test GitOps repo with updated image tag  
- [x] ArgoCD detects change and syncs Dev environment (if configured)  
- [x] No manual intervention required  
- [x] Git history remains clean and traceable  

---

## Checklist

- [x] `rollout-patch.yaml` correctly updated  in Dev environment
- [x] PR automation verified  
- [x] Used `github.sha` for consistent traceability 

---

## 📌 Related Issue  
Closes #11
 
