### PR TITLE
Promote Image to Staging on Release Branch Push

### DIFF
--- a/.github/workflows/promote-to-staging.yaml
+++ b/.github/workflows/promote-to-staging.yaml
@@ -1,0 +1,177 @@
+name: Java CD - Promote to Staging
+
+on:
+  push:
+    branches:
+      - release/**
+    paths:
+      - 'src/**'            
+      - 'pom.xml'
+      - 'Dockerfile'           
+      - 'scripts/**'        
+      - 'config/**'
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  docker-build-and-scan:
+    name: Docker Build and Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: docker-${{ github.sha }}
+          restore-keys: docker-
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Azure ACR Login
+        run: |
+          az acr login --name ${{ secrets.ACR_NAME }}
+
+      - name: Build Docker Image
+        run: |
+          IMAGE_TAG=${{ secrets.ACR_NAME }}.azurecr.io/pharma-staging:${{ github.sha }}
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          docker build -t $IMAGE_TAG .
+
+      - name: Scan Docker Image with Trivy and export report
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "image"
+          severity: CRITICAL,HIGH
+          scan-ref: ${{ env.IMAGE_TAG }}
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          output: "trivy-image-report.txt"
+
+      - name: Push Image to ACR
+        run: |
+          ACR_TAG=${{ secrets.ACR_NAME }}.azurecr.io/pharma-staging:${{ github.sha }}
+          docker push $ACR_TAG
+
+  update-gitops-staging:
+    needs: docker-build-and-scan
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+    steps:
+      - name: Checkout GitOps Repo
+        uses: actions/checkout@v3
+        with:
+          repository: Vikas-Prince/test-ops
+          token: ${{ secrets.GHCR_TOKEN }}
+          path: test-ops
+
+      - name: Set Git user config
+        run: |
+          cd test-ops
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: Update image tag in Staging YAML
+        run: |
+          cd test-ops
+          sed -i "s|image: .*|image: ${{ secrets.ACR_LOGIN_SERVER }}/${{ secrets.ACR_NAME }}/csi-pharma-staging:${{ env.IMAGE_TAG }}|" environments/staging/rollout-patch.yaml
+
+      - name: Create PR to GitOps (Staging)
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GHCR_TOKEN }}
+          commit-message: "chore(staging): update csi-pharma-staging image tag to ${IMAGE_TAG} in Dev"
+          title: "Deploy to Staging - ${{ env.IMAGE_TAG }}"
+          body: |
+            Automated deployment to the Staging environment.
+            This PR updates the image tag for csi-pharma-staging to version ${IMAGE_TAG}.
+            The deployment is triggered by a commit to the main branch and is part of the CI/CD pipeline
+          base: main
+          branch: auto/update-staging-${{ github.sha }}
+          path: test-ops
+
+  slack-notify:
+    runs-on: ubuntu-latest
+    needs: update-gitops-staging
+    steps:
+      - name: 📢 Slack Notification (End of Pipeline)
+        if: always()
+        run: |
+          STATUS="${{ job.status }}"
+          
+          if [ "$STATUS" == "success" ]; then
+            COLOR="good"
+            MESSAGE="Deployment succeeded! 🎉"
+            STATUS_ICON=":white_check_mark:"
+          elif [ "$STATUS" == "failure" ]; then
+            COLOR="danger"
+            MESSAGE="Deployment failed! ❌ Please check the logs."
+            STATUS_ICON=":x:"
+          elif [ "$STATUS" == "cancelled" ]; then
+            COLOR="warning"
+            MESSAGE="Deployment was canceled! ⚠️"
+            STATUS_ICON=":warning:"
+          elif [ "$STATUS" == "skipped" ]; then
+            COLOR="gray"
+            MESSAGE="Job was skipped. ⏸️"
+            STATUS_ICON=":pause_button:"
+          else
+            COLOR="gray"
+            MESSAGE="Pipeline completed with status: $STATUS"
+            STATUS_ICON=":question:"
+          fi
+
+          PAYLOAD="{
+            \"text\": \"*CI/CD Pipeline - $STATUS* $STATUS_ICON\",
+            \"attachments\": [
+              {
+                \"fallback\": \"Job Details\",
+                \"color\": \"$COLOR\",
+                \"fields\": [
+                  {
+                    \"title\": \"Repository\",
+                    \"value\": \"${{ github.repository }}\",
+                    \"short\": true
+                  },
+                  {
+                    \"title\": \"Branch\",
+                    \"value\": \"${{ github.ref_name }}\",
+                    \"short\": true
+                  },
+                  {
+                    \"title\": \"Job\",
+                    \"value\": \"${{ github.job }}\",
+                    \"short\": true
+                  },
+                  {
+                    \"title\": \"Commit\",
+                    \"value\": \"<https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>\",
+                    \"short\": false
+                  },
+                  {
+                    \"title\": \"Author\",
+                    \"value\": \"${{ github.actor }}\",
+                    \"short\": true
+                  },
+                ]
+              }
+            ]
+          }"
+
+          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
This PR introduces a workflow that automates promotion of Docker images to the **staging** environment when a commit is pushed to any `release/**` branch.

---

## Workflow:

- Builds and tags the image using the commit SHA.
- Performs a **Trivy scan** to ensure no HIGH/CRITICAL vulnerabilities.
- Pushes the image securely to **Azure Container Registry (ACR)** using OIDC.
- Patches the **GitOps rollout manifest for staging** with the new image tag.
- Automatically creates a PR to update the GitOps repository.
- Sends a detailed **Slack alert** with metadata including tag, environment, status, and job URL.

---

## Acceptance Criteria
- [x] Workflow triggers only on `release/**` branch push
- [x] Trivy scan runs and fails on vulnerabilities
- [x] Docker image pushed to ACR with correct tag
- [x] GitOps repo is patched via PR
- [x] Slack alert is successfully sent

> Everything tested and working as expected.

## Related
Close #30 
